### PR TITLE
Fix alignment of hero section text on mobile screens

### DIFF
--- a/src/componenets/Hero.jsx
+++ b/src/componenets/Hero.jsx
@@ -19,7 +19,7 @@ const Hero = () => {
 
         {/* Left Section - Text Content */}
         <div className="w-full lg:w-1/2">
-            <div className="flex flex-col items-center lg:items-start">
+            <div className="flex flex-col items-start lg:items-start">
 
                 {/* Animated Name */}
                 <motion.h1 


### PR DESCRIPTION
- Removed items-center class from the parent div to ensure left alignment on all screen sizes.
- Applied items-start for consistent left alignment across all devices.